### PR TITLE
Add equality overloads and operators to RangeValuePair

### DIFF
--- a/RangeTree/RangeValuePair.cs
+++ b/RangeTree/RangeValuePair.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace MB.Algodat
@@ -8,7 +8,7 @@ namespace MB.Algodat
     /// Both values must be of the same type and comparable.
     /// </summary>
     /// <typeparam name="TKey">Type of the values.</typeparam>
-    public struct RangeValuePair<TKey, TValue>
+    public struct RangeValuePair<TKey, TValue> : IEquatable<RangeValuePair<TKey, TValue>>
     {
         public TKey From { get; }
         public TKey To { get; }
@@ -45,6 +45,31 @@ namespace MB.Algodat
             if (Value != null)
                 hash = hash * 37 + Value.GetHashCode();
             return hash;
+        }
+
+        public bool Equals(RangeValuePair<TKey, TValue> other)
+        {
+            return EqualityComparer<TKey>.Default.Equals(From, other.From)
+                && EqualityComparer<TKey>.Default.Equals(To, other.To)
+                && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is RangeValuePair<TKey, TValue>))
+                return false;
+
+            return Equals((RangeValuePair<TKey, TValue>)obj);
+        }
+
+        public static bool operator ==(RangeValuePair<TKey, TValue> left, RangeValuePair<TKey, TValue> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(RangeValuePair<TKey, TValue> left, RangeValuePair<TKey, TValue> right)
+        {
+            return !(left == right);
         }
     }
 }


### PR DESCRIPTION
Thanks for a great fork!
You provide a strict superset of my ideas for improvement.

This PR adds equality overloads and operators to `RangeValuePair` to avoid boxing and reflection.

Calling `RangeTree.Contains` calls [`List<T>.Contains`](http://referencesource.microsoft.com/#mscorlib/system/collections/generic/list.cs,316) which uses `EqualityComparer<T>.Default` to compare elements.

The [Remarks](https://msdn.microsoft.com/en-us/library/ms224763.aspx#Remarks) for `EqualityComparer<T>.Default` states:
> The `Default` property checks whether type `T` implements the `System.IEquatable<T>` interface and, if so, returns an `EqualityComparer<T>` that uses that implementation. Otherwise, it returns an `EqualityComparer<T>` that uses the overrides of `Object.Equals` and `Object.GetHashCode` provided by `T`.

* `RangeValuePair` does not implement `IEquatable<RangeValuePair>` so `Object.Equals` is used instead.
* Because `RangeValuePair` is a struct calling `Object.Equals` causes boxing on *each* comparison.
* As `RangeValuePair` does not override `Equals(object obj)` 
[reflection](http://referencesource.microsoft.com/#mscorlib/system/valuetype.cs,26) is called, which uses reflection to compare the instance fields.